### PR TITLE
Features/87 bq2gcs go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get -qqy update && apt-get install -qqy \
         lsb-release \
         openssh-client \
         git \
+        vim \
         uuid-runtime \
         make \
         gnupg && \
@@ -51,10 +52,11 @@ COPY . /opt/project
 RUN pip install -r requirements.txt
 RUN pip install -e .
 RUN go get -u cloud.google.com/go/bigquery && \
+    go get github.com/google/uuid && \
     mkdir -p $GOGFW && \
     ln -s /opt/project/src/ $GOBQ2GCS && \
     cd $GOBQ2GCS && \
     go install
 
 # Setup the entrypoint for quickly executing the pipelines
-ENTRYPOINT ["go/bin/pipe-bq2gcs"]
+ENTRYPOINT ["pipe-bq2gcs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,18 +29,16 @@ RUN apt-get -qqy update && apt-get install -qqy \
     apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 \
        && gcloud --version
 
-#===+GoLang
+# Install go
 ENV GOLANG_VERSION="go1.14.3.linux-amd64"
 ENV PATH /usr/local/go/bin:$PATH
-RUN wget -q https://dl.google.com/go/${GOLANG_VERSION}.tar.gz && \
-    tar -C /usr/local -xzf ${GOLANG_VERSION}.tar.gz && \
-    rm -f ${GOLANG_VERSION}.tar.gz
-# Must be defined after installing go.
 ENV GOPATH=/opt/project/go
 ENV GOGFW=$GOPATH/src/github.com/GlobalFishingWatch
 ENV GOBQ2GCS=$GOGFW/pipe-bq2gcs
 ENV PATH $GOPATH/bin:$PATH
-#===-GoLang
+RUN wget -q https://dl.google.com/go/${GOLANG_VERSION}.tar.gz && \
+    tar -C /usr/local -xzf ${GOLANG_VERSION}.tar.gz && \
+    rm -f ${GOLANG_VERSION}.tar.gz
 
 # Setup a volume for configuration and auth data
 VOLUME ["/root/.config"]
@@ -52,14 +50,11 @@ COPY . /opt/project
 # Required to build the Docker Image
 RUN pip install -r requirements.txt
 RUN pip install -e .
-
-# Setup the entrypoint for quickly executing the pipelines
-# ENTRYPOINT ["scripts/run.sh"]
-#===+GoLang
-ENTRYPOINT ["go/bin/pipe-bq2gcs"]
 RUN go get -u cloud.google.com/go/bigquery && \
     mkdir -p $GOGFW && \
     ln -s /opt/project/src/ $GOBQ2GCS && \
     cd $GOBQ2GCS && \
     go install
-#===-GoLang
+
+# Setup the entrypoint for quickly executing the pipelines
+ENTRYPOINT ["go/bin/pipe-bq2gcs"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
     image: gfw/pipe-bq2gcs
     build: .
     volumes:
-      - ".:/opt/project"
       - "gcp:/root/.config/"
 
   gcloud:
@@ -19,7 +18,6 @@ services:
     build: .
     entrypoint: /bin/bash
     volumes:
-      - ".:/opt/project"
       - "gcp:/root/.config/"
 
 # Use an external named volume so that we can share gcp auth across containers

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
     build: .
     entrypoint: /bin/bash
     volumes:
+      - "./src:/opt/project/src"
       - "gcp:/root/.config/"
 
 # Use an external named volume so that we can share gcp auth across containers

--- a/scripts/bq2gcs.sh
+++ b/scripts/bq2gcs.sh
@@ -70,11 +70,16 @@ echo "  Inserted results in table ${TEMPORAL_TABLE}"
 # Export the results to GCS.
 #################################################################
 EXTENSION="csv"
-EXTRACT_PARAMS="--compression ${COMPRESSION}"
+EXTRACT_PARAMS=""
 if [ "${DESTINATION_FORMAT}" != "CSV" ]
 then
   EXTENSION="json"
-  EXTRACT_PARAMS="${EXTRACT_PARAMS} --destination_format ${DESTINATION_FORMAT}"
+  EXTRACT_PARAMS="--destination_format ${DESTINATION_FORMAT}"
+fi
+if [ "${COMPRESSION}" != "NONE" ]
+then
+  EXTRACT_PARAMS="${EXTRACT_PARAMS} --compression ${COMPRESSION}"
+  EXTENSION="${EXTENSION}.${COMPRESSION,,}"
 fi
 GCS_PATH=${GCS_OUTPUT_FOLDER}/${NAME}.${EXTENSION}
 bq extract ${EXTRACT_PARAMS} ${TEMPORAL_TABLE} ${GCS_PATH}

--- a/src/bq2gcs.go
+++ b/src/bq2gcs.go
@@ -60,10 +60,10 @@ func (bq2gcs *Bq2gcs) Run() {
   }
 
   var filename string
-  if bq2gcs.DestinationFormat == "JSON" {
-    filename, err = exportTableAsJSON(bq2gcs, uuidInstance)
-  } else {
+  if bq2gcs.DestinationFormat == "CSV" {
     filename, err = exportTableAsCSV(bq2gcs, uuidInstance)
+  } else {
+    filename, err = exportTableAsJSON(bq2gcs, uuidInstance)
   }
   if err != nil {
     log.Fatalf("Error get while extracting the data %v", err)

--- a/src/bq2gcs.go
+++ b/src/bq2gcs.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+  "context"
+  "fmt"
+  "log"
+
+  "cloud.google.com/go/bigquery"
+)
+
+type Bq2gcs struct{
+  Name string
+  JinjaQuery string
+  GCSOutputFolder string
+  DestinationFormat string
+}
+
+const ProjectId = "world-fishing-827"
+const TemporalDataset = "0_ttl24h"
+
+func usageMessage() {
+  fmt.Println("\nUsage:\nbq2gcs NAME JINJA_QUERY GCS_OUTPUT_FOLDER DESTINATION_FORMAT\n")
+  fmt.Println("NAME: Name to locate the kind of export and also used as temporal table name.")
+  fmt.Println("JINJA_QUERY: Jinja query to get the data to export.")
+  fmt.Println("GCS_OUTPUT_FOLDER: The Google Cloud Storage destination folder where will be stored the data.")
+  fmt.Println("DESTINATION_FORMAT: Destination format of the file.")
+  fmt.Println()
+}
+
+func (bq2gcs Bq2gcs) String() string {
+  return fmt.Sprintf("%v", bq2gcs)
+}
+
+func (bq2gcs *Bq2gcs) Run() {
+  fmt.Println("This is the Run method")
+
+  fmt.Println("Run the Jinja query and save it in a temporal table.")
+  fmt.Printf("temporalTable=%v.%s\n", TemporalDataset, bq2gcs.Name)
+
+  fmt.Println("=== Evaluation of the jinja ===")
+  fmt.Println(bq2gcs.JinjaQuery)
+  fmt.Println("=== Evaluation of the jinja ===")
+
+  err := makeQuery(bq2gcs.JinjaQuery, bq2gcs.Name)
+  if err != nil {
+    fmt.Println("Unable to run the query and store the data in the temporal table. %v", err)
+  }
+
+  return
+  if bq2gcs.DestinationFormat == "JSON" {
+    exportTableAsJSON(TemporalDataset, bq2gcs.Name, bq2gcs.GCSOutputFolder)
+  } else {
+    exportTableAsCSV(TemporalDataset, bq2gcs.Name, bq2gcs.GCSOutputFolder)
+  }
+}
+
+func makeQuery(sql, dstTableID string) error {
+  // Initializing the BigQuery Client
+  ctx := context.Background()
+
+  client, err := bigquery.NewClient(ctx, ProjectId)
+  if err != nil {
+    log.Fatalf("bigquery.NewClient: %v", err)
+  }
+  defer client.Close()
+
+  return nil
+  // Running the query
+  q := client.Query(sql)
+  q.QueryConfig.Dst = client.Dataset(TemporalDataset).Table(dstTableID)
+
+  // Start the job.
+  job, err := q.Run(ctx)
+  if err != nil {
+    return err
+  }
+
+  _, err = job.Wait(ctx)
+  if err != nil {
+    return err
+  }
+
+  return nil
+}
+
+func exportTableAsCSV(srcDataset, srcTable, gcsURI string) error {
+  ctx := context.Background()
+  client, err := bigquery.NewClient(ctx, ProjectId)
+  if err != nil {
+    return fmt.Errorf("bigquery.NewClient: %v", err)
+  }
+  defer client.Close()
+
+  gcsRef := bigquery.NewGCSReference(gcsURI + srcTable + ".csv")
+  gcsRef.FieldDelimiter = ","
+
+  extractor := client.DatasetInProject(ProjectId, srcDataset).Table(srcTable).ExtractorTo(gcsRef)
+  extractor.DisableHeader = true
+
+  extractor.Location = "US"
+
+  job, err := extractor.Run(ctx)
+  if err != nil {
+    return err
+  }
+  status, err := job.Wait(ctx)
+  if err != nil {
+    return err
+  }
+  if err := status.Err(); err != nil {
+    return err
+  }
+  return nil
+}
+
+func exportTableAsJSON(srcDataset, srcTable, gcsURI string) error {
+  ctx := context.Background()
+  client, err := bigquery.NewClient(ctx, ProjectId)
+  if err != nil {
+    return fmt.Errorf("bigquery.NewClient: %v", err)
+  }
+  defer client.Close()
+
+  gcsRef := bigquery.NewGCSReference(gcsURI + srcTable + ".json")
+  gcsRef.DestinationFormat = "JSON"
+
+  extractor := client.DatasetInProject(ProjectId, srcDataset).Table(srcTable).ExtractorTo(gcsRef)
+  extractor.DisableHeader = true
+
+  extractor.Location = "US"
+
+  job, err := extractor.Run(ctx)
+  if err != nil {
+    return err
+  }
+  status, err := job.Wait(ctx)
+  if err != nil {
+    return err
+  }
+  if err := status.Err(); err != nil {
+    return err
+  }
+  return nil
+}

--- a/src/bq2gcs.go
+++ b/src/bq2gcs.go
@@ -46,7 +46,6 @@ func (bq2gcs *Bq2gcs) Run() {
     fmt.Println("Unable to run the query and store the data in the temporal table. %v", err)
   }
 
-  return
   if bq2gcs.DestinationFormat == "JSON" {
     exportTableAsJSON(TemporalDataset, bq2gcs.Name, bq2gcs.GCSOutputFolder)
   } else {
@@ -64,7 +63,6 @@ func makeQuery(sql, dstTableID string) error {
   }
   defer client.Close()
 
-  return nil
   // Running the query
   q := client.Query(sql)
   q.QueryConfig.Dst = client.Dataset(TemporalDataset).Table(dstTableID)

--- a/src/run.go
+++ b/src/run.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+  "fmt"
+  "os"
+)
+
+func displayMessage() {
+  fmt.Println(
+    "Available Commands\n",
+    "  bq2gcs   Read query from BigQuery tables and save result to GCS.")
+}
+
+func informAndExit() {
+    displayMessage()
+    os.Exit(1)
+}
+
+func main() {
+  //Read arguments
+  if len(os.Args)<2 {
+    informAndExit()
+  }
+
+  args:=os.Args[1:]
+  switch args[:1][0] {
+    case "bq2gcs":
+      //Validation
+      bq2gcsArgs:=args[1:]
+      if len(bq2gcsArgs) != 4 {
+        usageMessage()
+        os.Exit(1)
+      }
+      bq2gcs := Bq2gcs{
+        bq2gcsArgs[0],
+        bq2gcsArgs[1],
+        bq2gcsArgs[2],
+        bq2gcsArgs[3]}
+      bq2gcs.Run()
+    default:
+      informAndExit()
+  }
+}

--- a/src/run.go
+++ b/src/run.go
@@ -27,7 +27,7 @@ func main() {
     case "bq2gcs":
       //Validation
       bq2gcsArgs:=args[1:]
-      if len(bq2gcsArgs) != 4 {
+      if len(bq2gcsArgs) != 6 {
         usageMessage()
         os.Exit(1)
       }
@@ -35,7 +35,9 @@ func main() {
         bq2gcsArgs[0],
         bq2gcsArgs[1],
         bq2gcsArgs[2],
-        bq2gcsArgs[3]}
+        bq2gcsArgs[3],
+        bq2gcsArgs[4],
+        bq2gcsArgs[5]}
       bq2gcs.Run()
     default:
       informAndExit()


### PR DESCRIPTION
Related with> https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/104

One first implementation of handling the operations we need using go instead of bash.

Not for merge, just to discuss.

I share also the sizes of the images:

|REPOSITORY|TAG|IMAGE ID|CREATED|SIZE|
| --- | --- | --- | --- | --- |
|gfw/pipe-bq2gcs|latest|ab6cb921a6ad|8 hours ago|4.26GB|


And the time that demands some call functions that are needed to initiate and work with BQ API.

The call of:
```
go get -u cloud.google.com/go/bigquery
```
Demands:
```bash
real    6m45.747s
user    2m34.092s
sys     0m17.194s
```